### PR TITLE
Prevent PR creation date collision with subtitle

### DIFF
--- a/preview-src/index.css
+++ b/preview-src/index.css
@@ -205,8 +205,13 @@ body button.checkedOut svg {
 	margin-right: 8px;
 }
 
+.subtitle .author {
+	margin-right: 8px;
+}
+
 .subtitle .created-at {
 	margin-left: auto;
+	white-space: nowrap;
 }
 
 body .overview-title button {


### PR DESCRIPTION
Screen shoots from few screen sizes.
![ss](https://user-images.githubusercontent.com/6403957/46733377-6fed9c00-cc90-11e8-9d77-ab150c0858d4.png)
![ssmid](https://user-images.githubusercontent.com/6403957/46733381-71b75f80-cc90-11e8-848f-dff2176429a2.png)
![sswide](https://user-images.githubusercontent.com/6403957/46733384-73812300-cc90-11e8-847f-2a5aa451fa40.png)

- margin set to 8px to match space between author avatar and username.
- set white-space nowrap for PR creation date to prevent breaking date to few lines like:

> 8
> hours
> ago